### PR TITLE
Restrict urllib to versions before 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pylint-django==2.3.0
 pylint-plugin-utils==0.6
 selenium==3.141.0
 python-dotenv==0.10.1
+urllib3>=1.26.15,<2


### PR DESCRIPTION
Greater versions of urllib break the selenium webdriver http call. See issue here: https://stackoverflow.com/questions/76180798/jenkins-job-failing-for-urllib3-valueerror-timeout-value-connect-was-object-o